### PR TITLE
Add bower package definition file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "josh.js",
+  "version": "0.2.9",
+  "homepage": "http://sdether.github.io/josh.js/",
+  "authors": [
+    "Arne Claassen <arne@claassen.net>"
+  ],
+  "description": "Javascript Online SHell provides a toolkit for building bash-like command line consoles for web pages.",
+  "main": [
+    "js/readline.js",
+    "js/history.js",
+    "js/input.js",
+    "js/killring.js",
+    "js/pathhandler.js",
+    "js/shell.js"
+  ],
+  "keywords": [
+    "shell",
+    "josh"
+  ],
+  "license": "Apache 2.0",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I want to be able to use [bower](http://bower.io/) to install josh.js as a dependency on my projects. 

The file should work as is with a `bower register josh git@github.com:sdether/josh.js.git`, then josh.js can be installed with a `bower install josh`

:)
