### PR TITLE
Fixes for closure compiler builds

### DIFF
--- a/js/example.js
+++ b/js/example.js
@@ -45,7 +45,7 @@
     // -------------------------
 
     // Setup the `Underscore` template for displaying items in the `KillRing`.
-    var killringItemTemplate = _.template("<div><% _.each(items, function(item, i) { %><div><%- i %>&nbsp;<%- item %></div><% }); %></div>")
+    var killringItemTemplate = _.template("<div><% _.each(items, function(item, i) { %><div><%- i %>&nbsp;<%- item %></div><% }); %></div>");
 
     // Create a the command `killring` which will display all text currently in the `KillRing`, by attaching
     // a handler to the `Shell`.
@@ -125,7 +125,7 @@
     // references like `.` and `..`. In implementations that let you explore an hierarchy on a server, this function
     // would live on the server side and be called remotely via `getNode`.
     function findNode(current, parts, callback) {
-      if(!parts || parts.length == 0) {
+      if(!parts || parts.length === 0) {
         return callback(current);
       }
       if(parts[0] == ".") {
@@ -208,7 +208,7 @@
         boot: {},
         dev: {},
         etc: {
-          default: {},
+          'default': {},
           'rc.d': {},
           sysconfig: {},
           x11: {}
@@ -254,7 +254,7 @@
           },
           src: {}
         },
-        var: {
+        'var': {
           lib: {},
           lock: {},
           run: {},

--- a/js/input.js
+++ b/js/input.js
@@ -22,7 +22,7 @@ var Josh = Josh || {};
         var range = this.createTextRange();
         range.move("character", index);
         range.select();
-      } else if (this.selectionStart != null) {
+    } else if (this.selectionStart !== null) {
         this.setSelectionRange(index, index);
       }
       next();
@@ -34,7 +34,7 @@ var Josh = Josh || {};
       var range = el.createTextRange();
       range.moveStart('character', -el.value.length);
       return range.text.length;
-    } else if (el.selectionStart != null) {
+  } else if (el.selectionStart !== null) {
       return el.selectionStart;
     }
     return 0;
@@ -154,7 +154,7 @@ var Josh = Josh || {};
         readline.onChange(renderSpan);
       }
       readline.unbind({keyCode: Josh.Keys.Special.Tab});
-      readline.unbind({char: 'R', ctrlKey: true});
+      readline.unbind({'char': 'R', ctrlKey: true});
       readline.onActivate(function () {
         _active = true;
         activate();

--- a/js/readline.js
+++ b/js/readline.js
@@ -85,7 +85,7 @@ Josh.Version = "0.2.9";
       left: cmdLeft,
       right: cmdRight,
       cancel: cmdCancel,
-      delete: cmdDeleteChar,
+      'delete': cmdDeleteChar,
       backspace: cmdBackspace,
       kill_eof: cmdKillToEOF,
       kill_wordback: cmdKillWordBackward,
@@ -96,9 +96,9 @@ Josh.Version = "0.2.9";
       wordback: cmdBackwardWord,
       wordforward: cmdForwardWord,
       yank_rotate: cmdRotate
-    }
+  };
     var _keyMap = {
-      default: {
+      'default': {
         8: cmdBackspace,    // Backspace
         9: cmdComplete,     // Tab
         13: cmdDone,        // Enter
@@ -272,8 +272,8 @@ Josh.Version = "0.2.9";
       } else if(key.ctrlKey) {
         k.modifier = 'control';
       }
-      if(key.char) {
-        k.code = key.char.charCodeAt(0);
+      if(key['char']) {
+        k.code = key['char'].charCodeAt(0);
       }
       return k;
     }
@@ -674,7 +674,7 @@ Josh.Version = "0.2.9";
 
         // check for some special first keys, regardless of modifiers
         _console.log("key: " + e.keyCode);
-        var cmd = _keyMap.default[e.keyCode];
+        var cmd = _keyMap['default'][e.keyCode];
         // intercept ctrl- and meta- sequences (may override the non-modifier cmd captured above
         var mod;
         if(e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey) {
@@ -727,5 +727,3 @@ Josh.Version = "0.2.9";
     return self;
   };
 })(this);
-
-


### PR DESCRIPTION
There were just a few issues with compiling josh with the closure compiler.
Most of the errors were due to reserved words as key names.  For example:

```
{ delete: 'foo' }
```

Should be:

```
{ 'delete': 'foo' }
```

Beyond that, I changed a couple of linter-style things (missing semicolons, === instead of ==).
