### PR TITLE
Any call to local storage must be wrapped inside a try catch

### DIFF
--- a/js/history.js
+++ b/js/history.js
@@ -41,10 +41,12 @@ var Josh = Josh || {};
       }
     }
     function save() {
-      try {
-        _storage.setItem(_key, JSON.stringify(_history));
-      } catch(e) {
-        _console.log("Error accessing storage");
+      if (_storage) {
+        try {
+          _storage.setItem(_key, JSON.stringify(_history));
+        } catch(e) {
+          _console.log("Error accessing storage");
+        }
       }
     }
 


### PR DESCRIPTION
Issue:https://github.com/sdether/josh.js/issues/24
CodeReview: Aaron Mars, and Arne?

Wrapped any call to local storage methods, in a try catch. Browser storage mechanisms such as localstorage do not work in Safari Private browsing. This error is causing MindTouch methods to fail, thus causing alot of components to stop working.
